### PR TITLE
add delegate method for pin keyboard dismissal

### DIFF
--- a/Sources/TvOSPinKeyboardViewController.swift
+++ b/Sources/TvOSPinKeyboardViewController.swift
@@ -271,8 +271,10 @@ open class TvOSPinKeyboardViewController: UIViewController {
 
     @objc
     func menuButtonWasPressed() {
-        delegate?.pinKeyboardDidDismiss()
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true, completion: {
+            [weak self] in
+            self?.delegate?.pinKeyboardDidDismiss()
+        })
     }
 }
 

--- a/Sources/TvOSPinKeyboardViewController.swift
+++ b/Sources/TvOSPinKeyboardViewController.swift
@@ -110,6 +110,7 @@ open class TvOSPinKeyboardViewController: UIViewController {
         setUpDeleteButton()
         
         setUpContrainsts()
+        setUpGestureRecognizer()
     }
     
     private func setUpBackgroundView() {
@@ -249,6 +250,12 @@ open class TvOSPinKeyboardViewController: UIViewController {
             titleLabel.centerX == view.centerX
         }
     }
+
+    private func setUpGestureRecognizer() {
+        let menuPressRecognizer = UITapGestureRecognizer(target: self, action: .menuButtonWasPressed)
+        menuPressRecognizer.allowedPressTypes = [NSNumber(integerLiteral: UIPress.PressType.menu.rawValue)]
+        view.addGestureRecognizer(menuPressRecognizer)
+    }
     
     @objc
     func numPadButtonWasPressed(sender: FocusTvButton) {
@@ -261,9 +268,16 @@ open class TvOSPinKeyboardViewController: UIViewController {
     func deleteButtonWasPressed(sender: FocusTvButton) {
         introducedPin = String(introducedPin.dropLast())
     }
+
+    @objc
+    func menuButtonWasPressed() {
+        delegate?.pinKeyboardDidDismiss()
+        dismiss(animated: true, completion: nil)
+    }
 }
 
 private extension Selector {
     static let numPadButtonWasPressed = #selector(TvOSPinKeyboardViewController.numPadButtonWasPressed)
     static let deleteButtonWasPressed = #selector(TvOSPinKeyboardViewController.deleteButtonWasPressed)
+    static let menuButtonWasPressed = #selector(TvOSPinKeyboardViewController.menuButtonWasPressed)
 }

--- a/Sources/TvOSPinKeyboardViewController.swift
+++ b/Sources/TvOSPinKeyboardViewController.swift
@@ -36,6 +36,7 @@ open class TvOSPinKeyboardViewController: UIViewController {
     public var pinLength = defaultPinLength
 
     public weak var delegate: TvOSPinKeyboardViewDelegate?
+    public var callsCancelCompletion = false
     
     public var backgroundView: UIView!
     
@@ -69,6 +70,7 @@ open class TvOSPinKeyboardViewController: UIViewController {
     private var pinStack: UIStackView!
     private var numpadButtonsStack: UIStackView!
     private var deleteButton: FocusTvButton!
+    private var menuTapGestureRecognizer: UITapGestureRecognizer?
     
     private var introducedPin: String = "" {
         didSet {
@@ -98,6 +100,22 @@ open class TvOSPinKeyboardViewController: UIViewController {
         super.viewDidLoad()
         setUpView()
     }
+
+    override open func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        if callsCancelCompletion {
+            setUpGestureRecognizer()
+        }
+    }
+
+    override open func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        if callsCancelCompletion, let menuTapGestureRecognizer = menuTapGestureRecognizer {
+            view.removeGestureRecognizer(menuTapGestureRecognizer)
+        }
+    }
     
     // MARK: - Private
     
@@ -110,7 +128,6 @@ open class TvOSPinKeyboardViewController: UIViewController {
         setUpDeleteButton()
         
         setUpContrainsts()
-        setUpGestureRecognizer()
     }
     
     private func setUpBackgroundView() {
@@ -188,7 +205,6 @@ open class TvOSPinKeyboardViewController: UIViewController {
     }
     
     private func setUpDeleteButton() {
-        
         deleteButton = numpadButton(withTitle: deleteButtonTitle)
         deleteButton.titleLabel?.font = deleteButtonFont
         
@@ -201,7 +217,6 @@ open class TvOSPinKeyboardViewController: UIViewController {
                                                       right: numpadButtonsPadding)
         
         numpadButtonsStack.addArrangedSubview(deleteButton)
-        
     }
     
     private func numpadButton(withTitle title: String) -> FocusTvButton {
@@ -252,9 +267,12 @@ open class TvOSPinKeyboardViewController: UIViewController {
     }
 
     private func setUpGestureRecognizer() {
-        let menuPressRecognizer = UITapGestureRecognizer(target: self, action: .menuButtonWasPressed)
-        menuPressRecognizer.allowedPressTypes = [NSNumber(integerLiteral: UIPress.PressType.menu.rawValue)]
-        view.addGestureRecognizer(menuPressRecognizer)
+        menuTapGestureRecognizer = UITapGestureRecognizer(target: self, action: .menuButtonWasPressed)
+        menuTapGestureRecognizer?.allowedPressTypes = [NSNumber(integerLiteral: UIPress.PressType.menu.rawValue)]
+
+        if let menuTapGestureRecognizer = menuTapGestureRecognizer {
+            view.addGestureRecognizer(menuTapGestureRecognizer)
+        }
     }
     
     @objc
@@ -273,7 +291,7 @@ open class TvOSPinKeyboardViewController: UIViewController {
     func menuButtonWasPressed() {
         dismiss(animated: true, completion: {
             [weak self] in
-            self?.delegate?.pinKeyboardDidDismiss()
+            self?.delegate?.pinKeyboardDidCancel()
         })
     }
 }

--- a/Sources/TvOSPinKeyboardViewDelegate.swift
+++ b/Sources/TvOSPinKeyboardViewDelegate.swift
@@ -11,4 +11,5 @@ import Foundation
 public protocol TvOSPinKeyboardViewDelegate: class {
     
     func pinKeyboardDidEndEditing(pinCode: String)
+    func pinKeyboardDidDismiss()
 }

--- a/Sources/TvOSPinKeyboardViewDelegate.swift
+++ b/Sources/TvOSPinKeyboardViewDelegate.swift
@@ -11,5 +11,12 @@ import Foundation
 public protocol TvOSPinKeyboardViewDelegate: class {
     
     func pinKeyboardDidEndEditing(pinCode: String)
-    func pinKeyboardDidDismiss()
+    func pinKeyboardDidCancel()
+}
+
+extension TvOSPinKeyboardViewDelegate {
+
+    func pinKeyboardDidCancel() {
+        // override by subclass
+    }
 }

--- a/TvOSPinKeyboardExample/Podfile.lock
+++ b/TvOSPinKeyboardExample/Podfile.lock
@@ -8,9 +8,14 @@ PODS:
 DEPENDENCIES:
   - TvOSPinKeyboard (from `..`)
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Cartography
+    - FocusTvButton
+
 EXTERNAL SOURCES:
   TvOSPinKeyboard:
-    :path: ..
+    :path: ".."
 
 SPEC CHECKSUMS:
   Cartography: d295eb25ab54bb57eecd8c2f04e9648c850f1281
@@ -19,4 +24,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 49f6d32eb08ef7bbd4e3d5b84f30ea450f8e2179
 
-COCOAPODS: 1.3.1
+COCOAPODS: 1.7.5

--- a/TvOSPinKeyboardExample/TvOSPinKeyboardExample.xcodeproj/project.pbxproj
+++ b/TvOSPinKeyboardExample/TvOSPinKeyboardExample.xcodeproj/project.pbxproj
@@ -97,7 +97,6 @@
 				FFCCD0F11F399FA800E03E1D /* Frameworks */,
 				FFCCD0F21F399FA800E03E1D /* Resources */,
 				C34B296653ED9A9E1FBCB744 /* [CP] Embed Pods Frameworks */,
-				B9D73992022737DE1334C384 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -115,7 +114,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0900;
-				LastUpgradeCheck = 0900;
+				LastUpgradeCheck = 1030;
 				ORGANIZATIONNAME = "David Cordero";
 				TargetAttributes = {
 					FFCCD0F31F399FA800E03E1D = {
@@ -155,28 +154,13 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		B9D73992022737DE1334C384 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TvOSPinKeyboardExample/Pods-TvOSPinKeyboardExample-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		C34B296653ED9A9E1FBCB744 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-TvOSPinKeyboardExample/Pods-TvOSPinKeyboardExample-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-TvOSPinKeyboardExample/Pods-TvOSPinKeyboardExample-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Cartography/Cartography.framework",
 				"${BUILT_PRODUCTS_DIR}/FocusTvButton/FocusTvButton.framework",
 				"${BUILT_PRODUCTS_DIR}/TvOSPinKeyboard/TvOSPinKeyboard.framework",
@@ -189,7 +173,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-TvOSPinKeyboardExample/Pods-TvOSPinKeyboardExample-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-TvOSPinKeyboardExample/Pods-TvOSPinKeyboardExample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		CA6235FC2562E375E9EDC589 /* [CP] Check Pods Manifest.lock */ = {
@@ -239,6 +223,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -246,6 +231,7 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -296,6 +282,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -303,6 +290,7 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;

--- a/TvOSPinKeyboardExample/TvOSPinKeyboardExample/ViewController.swift
+++ b/TvOSPinKeyboardExample/TvOSPinKeyboardExample/ViewController.swift
@@ -32,4 +32,8 @@ class ViewController: UIViewController, TvOSPinKeyboardViewDelegate {
     func pinKeyboardDidEndEditing(pinCode: String) {
         pinLabel.text = "Your Pin Code is: " + pinCode
     }
+
+    func pinKeyboardDidDismiss() {
+        pinLabel.text = "Entering Pin Code was cancelled."
+    }
 }

--- a/TvOSPinKeyboardExample/TvOSPinKeyboardExample/ViewController.swift
+++ b/TvOSPinKeyboardExample/TvOSPinKeyboardExample/ViewController.swift
@@ -23,6 +23,7 @@ class ViewController: UIViewController, TvOSPinKeyboardViewDelegate {
         pinKeyboard.backgroundView = UIVisualEffectView(effect: backgroundBlurEffectSyle)
         
         pinKeyboard.delegate = self
+        pinKeyboard.callsCancelCompletion = true
         
         present(pinKeyboard, animated: true, completion: nil)
     }
@@ -33,7 +34,7 @@ class ViewController: UIViewController, TvOSPinKeyboardViewDelegate {
         pinLabel.text = "Your Pin Code is: " + pinCode
     }
 
-    func pinKeyboardDidDismiss() {
+    func pinKeyboardDidCancel() {
         pinLabel.text = "Entering Pin Code was cancelled."
     }
 }


### PR DESCRIPTION
In order to have a better error handling for more detailed business requirements a user needs to be informed about the dismissal of the pin keyboard.